### PR TITLE
Fix graphics artifacts issue in Aquarium

### DIFF
--- a/aquarium/aquarium.html
+++ b/aquarium/aquarium.html
@@ -818,7 +818,11 @@ void main() {
 
 </script>
 <script id="outerRefractionMapFragmentShader" type="text/something-not-javascript">
-precision mediump float;
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+  precision highp float;
+#else
+  precision mediump float;
+#endif
 uniform vec4 lightColor;
 varying vec4 v_position;
 varying vec2 v_texCoord;


### PR DESCRIPTION
Some vectors in fragment shader of Aquarium are interpolated from
vertex shader, but with different precision. They have highp precision
in VS, but mediump in FS, which causes some graphics artifacts in this
case.
This PR will close issue #4.