### PR TITLE
Enable "change view" feature for auqarium vr mode.

### DIFF
--- a/aquarium-vr/aquarium-vr.html
+++ b/aquarium-vr/aquarium-vr.html
@@ -128,9 +128,7 @@ CANVAS {
   <div class="clickable" id="setSetting6">1000</div>
   <div class="clickable" id="setSetting7">2000</div>
   <div class="clickable" id="setSetting8">4000</div>
-  <!--
   <div class="clickable" id="setSetting9">Change View</div>
-  -->
   <div class="clickable" id="setSetting10">Advanced</div>
   <div class="clickable" id="options">Options...
   <div id="optionsContainer">


### PR DESCRIPTION
WebVR return view matrix based on position of HMD. If we want to add "change view" feature to aquarium-vr mode, we cannot use the view matrix directly.
This patch calculate view matrix based on orientation that WebVR returned and enabled "change view" feature.