### PR TITLE
Improve Aquarium MS Edge compatibility

### DIFF
--- a/aquarium/aquarium.js
+++ b/aquarium/aquarium.js
@@ -513,15 +513,15 @@ function createProgramFromTags(
   }
 
   if (opt_reflection) {
-    fs = fs.replace(/^.*?\/\/ #noReflection\n/gm, "");
+    fs = fs.replace(/^.*?\/\/ #noReflection\r?\n/gm, "");
   } else {
-    fs = fs.replace(/^.*?\/\/ #reflection\n/gm, "");
+    fs = fs.replace(/^.*?\/\/ #reflection\r?\n/gm, "");
   }
 
   if (opt_normalMaps) {
-    fs = fs.replace(/^.*?\/\/ #noNormalMap\n/gm, "");
+    fs = fs.replace(/^.*?\/\/ #noNormalMap\r?\n/gm, "");
   } else {
-    fs = fs.replace(/^.*?\/\/ #normalMap\n/gm, "");
+    fs = fs.replace(/^.*?\/\/ #normalMap\r?\n/gm, "");
   }
 
   var vs = getScriptText(vertexTagId);


### PR DESCRIPTION
The regexpes used for shader code filtering need to allow CRLF besides just LF to be compatible with Edge when opening the page through a file: URL or using the server config included in the repository. The issue doesn't appear on webglsamples.org so it may be specific to a certain git configuration but with the patch either style of line endings will work.