### PR TITLE
Support WebSocket connection on HTTPS sites

### DIFF
--- a/aquarium/aquarium-common.js
+++ b/aquarium/aquarium-common.js
@@ -241,7 +241,8 @@ function setSetting(elem, id) {
  */
 function initializeCommon() {
   if (g.net.sync) {
-    var url = "ws:" + window.location.host;
+    var protocol = window.location.protocol == "https:" ? "wss:" : "ws:" 
+    var url = protocol + window.location.host;
     tdl.log("server:", url);
     g_syncManager.init(url, g.net.slave);
     if (!g.net.slave) {


### PR DESCRIPTION
Currently, WebGL Aquarium always uses unencrypted WS protocol. However, browsers will prevent accessing unencrypted protocol on HTTPS sites.

This PR adds a check if HTTPS is used and use encrypted WSS. And when HTTP is used, it continues using unencrypted WS protocol.

If there are more samples which are using WebSocket connection, they also need to be updated in similar way.