### PR TITLE
fishtank: Use highp for refractSkyboxFragmentShader

### DIFF
--- a/fishtank/fishtank.html
+++ b/fishtank/fishtank.html
@@ -1188,7 +1188,7 @@ void main() {
 </script>
 <script id="refractSkyboxFragmentShader" type="text/something-not-javascript">
 #ifdef GL_ES
-precision mediump float;
+precision highp float;
 #endif
 uniform samplerCube skybox;
 uniform mat4 viewProjectionInverse;


### PR DESCRIPTION
Without this the background flickers/tears on PowerVR and ARM Bifrost GPUs.