### PR TITLE
Fix video playback on mobile browsers

### DIFF
--- a/video/video.html
+++ b/video/video.html
@@ -264,8 +264,8 @@ void main() {
       var start = document.querySelector("#start");
       var once = false;
 
-      start.addEventListener('touchstart', onTouch);
-      start.addEventListener('mousedown', onTouch);
+      start.addEventListener('touchend', onTouch);
+      start.addEventListener('mouseup', onTouch);
       function onTouch() {
         if (once) {
           return;


### PR DESCRIPTION
Chrome on Android does not accept "touchstart" as a user gesture, so `video.play()` throws an error.