### PR TITLE
Aquarium fails if webgl2 not available

### DIFF
--- a/tdl/webgl.js
+++ b/tdl/webgl.js
@@ -98,17 +98,15 @@ tdl.webgl.OTHER_PROBLEM = '' +
  */
 tdl.webgl.setupWebGL = function(canvas, opt_attribs, opt_onError, opt_preferredContextType) {
   function handleCreationError(msg) {
-    var container = canvas.parentNode;
-    if (container) {
-      var str = window.WebGLRenderingContext ?
-           tdl.webgl.OTHER_PROBLEM :
-           tdl.webgl.GET_A_WEBGL_BROWSER;
-      if (msg) {
-        str += "<br/><br/>Status: " + msg;
-      }
-      container.innerHTML = tdl.webgl.makeFailHTML(str);
+    str = window.WebGLRenderingContext ?
+         tdl.webgl.OTHER_PROBLEM :
+         tdl.webgl.GET_A_WEBGL_BROWSER;
+    if (msg) {
+      str += "<br/><br/>Status: " + msg;
     }
   };
+
+  var str = "";
 
   opt_onError = opt_onError || handleCreationError;
 
@@ -131,6 +129,10 @@ tdl.webgl.setupWebGL = function(canvas, opt_attribs, opt_onError, opt_preferredC
       }, false);
     }
   } else {
+    var container = canvas.parentNode;
+    if (container) {
+      container.innerHTML = tdl.webgl.makeFailHTML(str);
+    }
     if (!window.WebGLRenderingContext) {
       opt_onError("");
     }


### PR DESCRIPTION
<pre>Since a short time aquarium totally fails if webgl2 not available.
I am running an old Dell laptop with linux Debian Testing
and firefox, which does not support webgl2.
It only shows a page with misleading errormessage:
&quot;It does not appear your computer supports WebGL&quot;
and loops with varying fps-count.

Problem is caused recent merge.
At aquarium/aquarium-config.js it sets enableVR: true,
causing webgl2 to become the preferred driver.
The first check for driver webgl2 fails, causing the
display of the error-page.
The next check for driver webgl succeeds, causing the
program to continue, but probably because of the active error-page,
it fails displaying the aquarium.

Problem can be solved at tdl/webgl.js at
tdl.webgl.setupWebGL.
Function handleCreationError should only
generate the message but not show it.
The message should be only shown at the end of
tdl.webgl.setupWebGL, if no context is available.
<font color="#2A7BDE">~      </font></pre>