### PR TITLE
Fix aquarium in Firefox. Only enable multiview when VR is supported

### DIFF
--- a/aquarium/aquarium.js
+++ b/aquarium/aquarium.js
@@ -60,6 +60,7 @@ var g_putCount = 0;
 
 var g_frameData;
 var g_vrUi;
+var g_vrSupported = false;
 
 var g_multiviewFb;        // multiview framebuffer.
 var g_multiviewViewFb;    // single views inside the multiview framebuffer.
@@ -536,7 +537,7 @@ function createProgramFromTags(
 
   var vs = getScriptText(vertexTagId);
 
-  if (multiview) {
+  if (g_vrSupported && multiview) {
     // Replace shader code to get ESSL3 shader code and enable multiview (huge hack, do not do this at home kids)
 
     var vsPrefix = ["#version 300 es"];
@@ -991,7 +992,7 @@ function initialize() {
   });
 
   var particleSystem = new tdl.particles.ParticleSystem(
-      gl, null, math.pseudoRandom);
+      gl, null, math.pseudoRandom, g_vrSupported);
   setupBubbles(particleSystem);
   var bubbleTimer = 0;
   var bubbleIndex = 0;
@@ -2273,6 +2274,7 @@ $(function(){
             vrButton = addButton("Enter VR", "E", vrButtonURL, onRequestPresent);
             g_vrUi = new Ui(gl, g_numFish);
             g_vrUi.load("./vr_assets/ui/config.js");
+            g_vrSupported = true;
           }
         });
         navigator.xr.addEventListener('devicechange', onDeviceChange);

--- a/tdl/particles.js
+++ b/tdl/particles.js
@@ -275,7 +275,8 @@ tdl.particles.CORNERS_ = [
  */
 tdl.particles.ParticleSystem = function(gl,
                                           opt_clock,
-                                          opt_randomFunction) {
+                                          opt_randomFunction,
+                                          opt_vrSupported) {
   this.gl = gl;
 
   // Entities which can be drawn -- emitters or OneShots
@@ -325,7 +326,7 @@ tdl.particles.ParticleSystem = function(gl,
   };
 
   var multiviewShaders = [];
-  if (gl.getExtension('OVR_multiview2')) {
+  if (opt_vrSupported && gl.getExtension('OVR_multiview2')) {
     multiviewShaders.push(new tdl.shader.Shader(gl,
                                                 makeShaderSourceMultiview('vs', tdl.particles.SHADER_STRINGS[0]),
                                                 makeShaderSourceMultiview('fs', tdl.particles.SHADER_STRINGS[2])));


### PR DESCRIPTION
The Aquarium sample is currently broken in Firefox on Ubuntu using Nvidia drivers with the following error.

```
Error compiling shader:
0(3) : error C0210: extension GL_OVR_multiview2 not supported for version 150
[log.js:69:22](https://webglsamples.org/tdl/log.js)
```

Apparently Firefox thinks OVR_multiview2 is available to use on Ubuntu since `gl.getExtension('OVR_multiview2')` returns with an extension object.

This PR changes the sample code to use multiview only if VR support is detected. Tested with Firefox and Chrome on Ubuntu, Windows, Vive Browser on Vive XR Elite, and Cardboard. Would appreciate help testing on a Quest device.